### PR TITLE
Add weather and quali features

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,13 +13,16 @@ This project uses historical Formula 1 data from the 2022-2024 seasons to build 
 - Qualifying position influence
 - Driver experience factors
 - Circuit-specific performance patterns
+- Weather conditions and overtaking difficulty metrics
+- Best qualifying and practice session times
 
 The system handles team changes for 2025 (like Hamilton moving to Ferrari) and accommodates rookies through team performance metrics.
 
 ## Key Features
 
 - **Data Collection**: Automated fetching of historical F1 race data using the FastF1 API
-- **Feature Engineering**: Comprehensive driver and team metrics creation
+- **Feature Engineering**: Comprehensive driver and team metrics creation, including
+  weather conditions, track overtaking difficulty, and detailed qualifying times
 - **Machine Learning**: Random Forest regression model to predict race finishing positions
 - **Team Change Handling**: Sophisticated method for handling 2025 driver lineup changes
 - **Visualization**: Three different visualizations of prediction results
@@ -72,6 +75,8 @@ This visualization shows:
    - Team performance metrics
    - Driver experience quantification
    - Circuit-specific indicators
+   - Weather measurements and overtaking difficulty
+   - Qualifying and practice session times
 
 3. **Machine Learning Model**
 
@@ -102,6 +107,8 @@ This visualization shows:
   ```
   pip install fastf1 pandas numpy scikit-learn matplotlib seaborn
   ```
+  The FastF1 package is required to access weather data and detailed qualifying
+  information used in the model.
 
 ### Installation
 

--- a/race_predictor.py
+++ b/race_predictor.py
@@ -42,6 +42,34 @@ DRIVERS_2025 = [
 
 DRIVERS_DF = pd.DataFrame(DRIVERS_2025)
 
+# Simplified overtaking difficulty metrics (1=easiest, 5=hardest)
+OVERTAKE_DIFFICULTY = {
+    'Bahrain Grand Prix': 2,
+    'Saudi Arabian Grand Prix': 2,
+    'Australian Grand Prix': 3,
+    'Japanese Grand Prix': 3,
+    'Chinese Grand Prix': 3,
+    'Miami Grand Prix': 2,
+    'Emilia Romagna Grand Prix': 4,
+    'Monaco Grand Prix': 5,
+    'Canadian Grand Prix': 3,
+    'Spanish Grand Prix': 4,
+    'Austrian Grand Prix': 2,
+    'British Grand Prix': 3,
+    'Hungarian Grand Prix': 4,
+    'Belgian Grand Prix': 2,
+    'Dutch Grand Prix': 4,
+    'Italian Grand Prix': 2,
+    'Azerbaijan Grand Prix': 3,
+    'Singapore Grand Prix': 5,
+    'United States Grand Prix': 3,
+    'Mexican Grand Prix': 3,
+    'Brazilian Grand Prix': 2,
+    'Las Vegas Grand Prix': 3,
+    'Qatar Grand Prix': 2,
+    'Abu Dhabi Grand Prix': 3,
+}
+
 # List of grand prix for selection (2024 schedule approximation)
 GRAND_PRIX_LIST = [
     'Bahrain Grand Prix',
@@ -76,12 +104,71 @@ def _load_historical_data(seasons):
     for season in seasons:
         for rnd in range(1, 23):
             try:
+                # Race session
                 session = fastf1.get_session(season, rnd, 'R')
                 session.load()
+
                 results = session.results[['DriverNumber', 'Position', 'Points', 'GridPosition']]
                 results['Season'] = season
                 results['RaceNumber'] = rnd
                 results['Circuit'] = session.event['EventName']
+
+                # Weather information
+                try:
+                    weather = session.weather_data
+                    results['AirTemp'] = weather['AirTemp'].mean()
+                    results['TrackTemp'] = weather['TrackTemp'].mean()
+                    results['Rainfall'] = weather['Rainfall'].max()
+                except Exception:
+                    results['AirTemp'] = np.nan
+                    results['TrackTemp'] = np.nan
+                    results['Rainfall'] = np.nan
+
+                # Overtake difficulty
+                results['OvertakingDifficulty'] = OVERTAKE_DIFFICULTY.get(
+                    results['Circuit'].iloc[0], 3
+                )
+
+                # Qualifying data
+                try:
+                    q_session = fastf1.get_session(season, rnd, 'Q')
+                    q_session.load()
+                    q_results = q_session.results[['DriverNumber', 'Position', 'Q1', 'Q2', 'Q3']]
+
+                    def _best_time(row):
+                        times = []
+                        for col in ['Q1', 'Q2', 'Q3']:
+                            val = row[col]
+                            if pd.notna(val):
+                                try:
+                                    times.append(pd.to_timedelta(val).total_seconds())
+                                except Exception:
+                                    pass
+                        return min(times) if times else np.nan
+
+                    q_results['BestQualiTime'] = q_results.apply(_best_time, axis=1)
+                    q_results = q_results.rename(columns={'Position': 'QualiPosition'})
+                    results = pd.merge(results, q_results[['DriverNumber', 'BestQualiTime', 'QualiPosition']], on='DriverNumber', how='left')
+                except Exception:
+                    results['BestQualiTime'] = np.nan
+                    results['QualiPosition'] = np.nan
+
+                # FP3 best lap
+                try:
+                    fp3_session = fastf1.get_session(season, rnd, 'FP3')
+                    fp3_session.load()
+                    best_laps = (
+                        fp3_session.laps
+                        .groupby('DriverNumber')['LapTime']
+                        .min()
+                        .dt.total_seconds()
+                        .reset_index()
+                        .rename(columns={'LapTime': 'FP3BestTime'})
+                    )
+                    results = pd.merge(results, best_laps, on='DriverNumber', how='left')
+                except Exception:
+                    results['FP3BestTime'] = np.nan
+
                 race_data.append(results)
             except Exception:
                 continue
@@ -117,6 +204,13 @@ def _add_driver_team_info(full_data, seasons):
 def _engineer_features(full_data):
     full_data['Position'] = pd.to_numeric(full_data['Position'], errors='coerce').fillna(25)
     full_data['GridPosition'] = pd.to_numeric(full_data['GridPosition'], errors='coerce').fillna(25)
+    full_data['AirTemp'] = pd.to_numeric(full_data['AirTemp'], errors='coerce')
+    full_data['TrackTemp'] = pd.to_numeric(full_data['TrackTemp'], errors='coerce')
+    full_data['Rainfall'] = pd.to_numeric(full_data['Rainfall'], errors='coerce')
+    full_data['OvertakingDifficulty'] = pd.to_numeric(full_data['OvertakingDifficulty'], errors='coerce')
+    full_data['BestQualiTime'] = pd.to_numeric(full_data['BestQualiTime'], errors='coerce')
+    full_data['QualiPosition'] = pd.to_numeric(full_data['QualiPosition'], errors='coerce')
+    full_data['FP3BestTime'] = pd.to_numeric(full_data['FP3BestTime'], errors='coerce')
 
     full_data.sort_values(['Season', 'RaceNumber'], inplace=True)
     full_data['ExperienceCount'] = full_data.groupby('DriverNumber').cumcount() + 1
@@ -136,6 +230,14 @@ def _engineer_features(full_data):
     full_data = pd.merge(full_data, team_perf, on=['HistoricalTeam', 'Season'], how='left')
     full_data['TeamAvgPosition'] = full_data['TeamAvgPosition'].fillna(full_data['TeamAvgPosition'].mean())
 
+    full_data['AirTemp'] = full_data['AirTemp'].fillna(full_data['AirTemp'].mean())
+    full_data['TrackTemp'] = full_data['TrackTemp'].fillna(full_data['TrackTemp'].mean())
+    full_data['Rainfall'] = full_data['Rainfall'].fillna(0)
+    full_data['OvertakingDifficulty'] = full_data['OvertakingDifficulty'].fillna(3)
+    full_data['BestQualiTime'] = full_data['BestQualiTime'].fillna(full_data['BestQualiTime'].mean())
+    full_data['QualiPosition'] = full_data['QualiPosition'].fillna(20)
+    full_data['FP3BestTime'] = full_data['FP3BestTime'].fillna(full_data['FP3BestTime'].mean())
+
     return full_data
 
 
@@ -152,7 +254,21 @@ def _encode_features(full_data):
     circuit_df = circuit_df[top_circuits]
 
     features = pd.concat([
-        full_data[['GridPosition', 'Season', 'ExperienceCount', 'TeamAvgPosition', 'RecentAvgPosition', 'RecentAvgPoints']],
+        full_data[[
+            'GridPosition',
+            'Season',
+            'ExperienceCount',
+            'TeamAvgPosition',
+            'RecentAvgPosition',
+            'RecentAvgPoints',
+            'AirTemp',
+            'TrackTemp',
+            'Rainfall',
+            'OvertakingDifficulty',
+            'BestQualiTime',
+            'QualiPosition',
+            'FP3BestTime',
+        ]],
         team_df,
         circuit_df
     ], axis=1)
@@ -185,6 +301,14 @@ def predict_race(grand_prix):
     target = race_data['Position']
     model = _train_model(features, target)
 
+    default_air = race_data['AirTemp'].mean()
+    default_track = race_data['TrackTemp'].mean()
+    default_rain = 0.0
+    default_overtake = 3
+    default_best_q = race_data['BestQualiTime'].mean()
+    default_qpos = race_data['QualiPosition'].mean()
+    default_fp3 = race_data['FP3BestTime'].mean()
+
     # Prepare prediction dataframe for all drivers
     pred_rows = []
     team_strength = race_data[race_data['Season'] == 2024].groupby('HistoricalTeam')['Position'].mean().reset_index()
@@ -208,6 +332,13 @@ def predict_race(grand_prix):
             'TeamAvgPosition': team_avg_pos,
             'RecentAvgPosition': 10.0,
             'RecentAvgPoints': 0.0,
+            'AirTemp': default_air,
+            'TrackTemp': default_track,
+            'Rainfall': default_rain,
+            'OvertakingDifficulty': default_overtake,
+            'BestQualiTime': default_best_q,
+            'QualiPosition': default_qpos,
+            'FP3BestTime': default_fp3,
             'Team': d['Team'],
             'FullName': d['FullName'],
             'Abbreviation': d['Abbreviation']
@@ -229,7 +360,21 @@ def predict_race(grand_prix):
     circuit_df = circuit_df.reindex(columns=top_circuits, fill_value=0)
 
     pred_features = pd.concat([
-        pred_df[['GridPosition', 'Season', 'ExperienceCount', 'TeamAvgPosition', 'RecentAvgPosition', 'RecentAvgPoints']].reset_index(drop=True),
+        pred_df[[
+            'GridPosition',
+            'Season',
+            'ExperienceCount',
+            'TeamAvgPosition',
+            'RecentAvgPosition',
+            'RecentAvgPoints',
+            'AirTemp',
+            'TrackTemp',
+            'Rainfall',
+            'OvertakingDifficulty',
+            'BestQualiTime',
+            'QualiPosition',
+            'FP3BestTime',
+        ]].reset_index(drop=True),
         team_enc_df.reset_index(drop=True),
         circuit_df.reset_index(drop=True)
     ], axis=1)


### PR DESCRIPTION
## Summary
- capture weather info and overtaking difficulty per race
- pull qualifying and FP3 times
- expand feature engineering to incorporate new data
- document new features and FastF1 usage

## Testing
- `python -m py_compile race_predictor.py`
- `python race_predictor.py` *(fails: ModuleNotFoundError: No module named 'fastf1')*

------
https://chatgpt.com/codex/tasks/task_b_683b22a7d61c8331bab8339fcd9f4969