### PR TITLE
Add sprint sessions and detailed qualy times

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -155,14 +155,14 @@ The full prediction includes expected finishing positions for all 20 drivers com
 
 ## Race Details Export
 
-Use `export_race_details.py` to save session weather summaries for a Grand Prix.
+Use `export_race_details.py` to save session weather summaries and driver lap times for a Grand Prix.
 Example:
 
 ```bash
 python export_race_details.py 2024 "Monaco"
 ```
 
-This creates a CSV in the `race_details` folder with FP3, Qualifying and Race temperatures.
+This creates a CSV in the `race_details` folder containing weather data plus each driver's session results. The CSV now lists best FP3 laps, detailed Q1--Q3 times, sprint shootout times, and race or sprint finishing positions when available.
 
 ## Resources
 


### PR DESCRIPTION
## Summary
- add Q1/Q2/Q3 and sprint shootout columns in `export_race_details.py`
- capture sprint and sprint shootout sessions if available
- document expanded session export in `ReadMe`

## Testing
- `python -m py_compile export_race_details.py`

------
https://chatgpt.com/codex/tasks/task_b_683b500a266c8331a7ed6e301fa41ab3