### PR TITLE
Improve grid prediction

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -82,10 +82,10 @@ This visualization shows:
 
    - Random Forest Regressor trained on historical finishing positions
    - Feature importance analysis to understand prediction factors
-   - Position randomization with team-weighted probabilities for qualifying simulation
+ - Separate model to predict qualifying positions instead of random simulation
 
 4. **Prediction Generation**
-   - Qualifying simulation based on team strength
+   - Qualifying grid predicted using the dedicated model
    - Race position prediction using the trained model
    - Analysis of expected position changes during the race
 


### PR DESCRIPTION
## Summary
- use a qualifying model to predict starting grid
- rebuild final position features to use predicted qualifying
- update README to describe improved qualifying model

## Testing
- `python -m py_compile race_predictor.py`

------
https://chatgpt.com/codex/tasks/task_b_683b571d68c083319741bf54f93be0ef