### PR TITLE
Handle missing driver data gracefully

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -6,7 +6,10 @@ st.title('F1 2025 Race Predictor')
 gp = st.selectbox('Select a Grand Prix', GRAND_PRIX_LIST)
 
 if st.button('Predict Results'):
-    with st.spinner('Running predictions...'):
-        results = predict_race(gp)
-    st.subheader('Predicted Finishing Positions')
-    st.dataframe(results[['Final_Position', 'Driver', 'Team', 'Grid']])
+    try:
+        with st.spinner('Running predictions...'):
+            results = predict_race(gp)
+        st.subheader('Predicted Finishing Positions')
+        st.dataframe(results[['Final_Position', 'Driver', 'Team', 'Grid']])
+    except Exception as e:
+        st.error(str(e))


### PR DESCRIPTION
## Summary
- avoid errors when encoding features with no rows
- raise a helpful error if no driver info is available
- surface exceptions in Streamlit app

## Testing
- `python -m py_compile race_predictor.py webapp.py`
- `python race_predictor.py` *(fails: ModuleNotFoundError: No module named 'fastf1')*

------
https://chatgpt.com/codex/tasks/task_b_683b77fb99588331801369c12d2ae5e6