### PR TITLE
Add option to export predicted race data

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -164,6 +164,14 @@ python export_race_details.py 2024 "Monaco"
 
 This creates a CSV in the `race_details` folder containing weather data plus each driver's session results. The CSV now lists best FP3 laps, detailed Q1--Q3 times, sprint shootout times, and race or sprint finishing positions when available.
 
+The `predict_race` function can also export these details for the selected event
+by passing `export_details=True`:
+
+```python
+from race_predictor import predict_race
+predict_race("Monaco Grand Prix", year=2025, export_details=True)
+```
+
 ## Resources
 
 - [FastF1 Documentation](https://theoehrly.github.io/Fast-F1/)

--- a/race_predictor.py
+++ b/race_predictor.py
@@ -4,6 +4,7 @@ import warnings
 
 import fastf1
 import requests
+from export_race_details import export_race_details
 import numpy as np
 import pandas as pd
 from sklearn.preprocessing import OneHotEncoder
@@ -506,7 +507,7 @@ def _train_model(features, target, cv):
     return model
 
 
-def predict_race(grand_prix, year=2025):
+def predict_race(grand_prix, year=2025, export_details=False):
     seasons = [2022, 2023, 2024]
     race_data = _load_historical_data(seasons)
     race_data = race_data.reset_index(drop=True)
@@ -703,11 +704,17 @@ def predict_race(grand_prix, year=2025):
     results['Final_Position'] = range(1, len(results) + 1)
     # Save the final ordered predictions for transparency
     results.to_csv("prediction_results.csv", index=False)
+    if export_details:
+        try:
+            detail_path = export_race_details(year, grand_prix)
+            print(f"Saved session data to {detail_path}")
+        except Exception as err:
+            print(f"Could not export session data: {err}")
     print(f"Grid MAE on training data: {grid_mae:.2f}")
     print(f"Finish MAE on training data: {finish_mae:.2f}")
     return results
 
 
 if __name__ == '__main__':
-    res = predict_race('Chinese Grand Prix', year=2025)
+    res = predict_race('Chinese Grand Prix', year=2025, export_details=True)
     print(res[['Driver', 'Team', 'Grid', 'Final_Position']].head())


### PR DESCRIPTION
## Summary
- support exporting FP3/Q1/Q2/Q3 data when running predictions
- show how to call this in the README

## Testing
- `python3 -m py_compile race_predictor.py export_race_details.py webapp.py`

------
https://chatgpt.com/codex/tasks/task_b_683b85e7a494833196557e4206d6d8fd