### PR TITLE
Add 2025 season export utility

### DIFF
--- a/generate_2025_data.py
+++ b/generate_2025_data.py
@@ -1,0 +1,39 @@
+import os
+import pandas as pd
+
+try:
+    import fastf1
+except ImportError as exc:
+    raise SystemExit("fastf1 is required to run this script. Install via 'pip install fastf1'.") from exc
+
+from export_race_details import _fetch_session_data
+
+def export_full_season(year: int = 2025, output_file: str = "prediction_data_race_2025.csv") -> str:
+    """Collect FP3, qualifying and race data for all events in a season."""
+    cache_dir = 'f1_cache'
+    os.makedirs(cache_dir, exist_ok=True)
+    fastf1.Cache.enable_cache(cache_dir)
+
+    schedule = fastf1.get_event_schedule(year)
+    data_frames = []
+    for _, row in schedule.iterrows():
+        gp = row['EventName']
+        round_num = int(row['RoundNumber'])
+        for code in ['FP3', 'Q', 'SQ', 'S', 'R']:
+            try:
+                df = _fetch_session_data(year, round_num, code)
+                df['EventName'] = gp
+                data_frames.append(df)
+            except Exception as err:
+                print(f"Failed to load {year} {gp} {code}: {err}")
+
+    if not data_frames:
+        raise RuntimeError("No data collected for season")
+
+    season_df = pd.concat(data_frames, ignore_index=True)
+    season_df.to_csv(output_file, index=False)
+    return output_file
+
+if __name__ == "__main__":
+    path = export_full_season()
+    print(f"Saved full season data to {path}")

--- a/prediction_data_race_2025.csv
+++ b/prediction_data_race_2025.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75010b6e1feb4a0659afeb342699e37198ddbef5c1c404e0da5989601eb0ebd6
+size 183


### PR DESCRIPTION
## Summary
- add `generate_2025_data.py` script to pull FP3, qualifying and race details for all events in a season
- include a placeholder `prediction_data_race_2025.csv` showing expected output format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b893365388331967d70ae41166fda