### PR TITLE
Add dynamic overtake estimation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -192,7 +192,10 @@ python estimate_overtakes.py "Monaco Grand Prix" 2022 2023 2024
 ```
 
 Save the values for all circuits in `overtake_stats.csv` and the
-prediction model will use them automatically.
+prediction model will use them automatically. When running the Streamlit app,
+if a circuit's statistics are missing, the application now calculates the
+average overtakes for the last few seasons on the fly before generating the
+prediction.
 
 ## Resources
 

--- a/webapp.py
+++ b/webapp.py
@@ -8,7 +8,7 @@ gp = st.selectbox('Select a Grand Prix', GRAND_PRIX_LIST)
 if st.button('Predict Results'):
     try:
         with st.spinner('Running predictions...'):
-            results = predict_race(gp)
+            results = predict_race(gp, compute_overtakes=True)
         st.subheader('Predicted Finishing Positions')
         st.dataframe(results[['Final_Position', 'Driver', 'Team', 'Grid']])
     except Exception as e:


### PR DESCRIPTION
## Summary
- compute average overtakes automatically when predicting a race
- call prediction with this calculation from the Streamlit app
- document the new behaviour in README

## Testing
- `python -m py_compile race_predictor.py webapp.py estimate_overtakes.py`


------
https://chatgpt.com/codex/tasks/task_b_683c01b1a128833191cd1b5dbee0d763