### PR TITLE
Use event schedule for historical data rounds

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,7 +21,7 @@ The system handles team changes for 2025 (like Hamilton moving to Ferrari) and a
 
 ## Key Features
 
-- **Data Collection**: Automated fetching of historical F1 race data using the FastF1 API
+- **Data Collection**: Automated fetching of historical F1 race data using the FastF1 API. Rounds are determined from the official schedule so any cancelled events are automatically skipped
 - **Feature Engineering**: Comprehensive driver and team metrics creation, including
   weather conditions, average overtakes metrics, and detailed qualifying times
  - **Machine Learning**: Two-stage XGBoost models optimized with Bayesian search to predict qualifying and race finishing positions
@@ -67,6 +67,7 @@ This visualization shows:
 1. **Data Collection**
 
    - Historical race results from 2020-2025 seasons
+   - Rounds are pulled from each season's event schedule so cancelled races are skipped automatically
    - Driver and team mappings
    - Circuit-specific performance patterns
 

--- a/race_predictor.py
+++ b/race_predictor.py
@@ -192,8 +192,18 @@ def _load_historical_data(seasons, overtake_map=None):
         overtake_map = OVERTAKE_AVERAGES
     race_data = []
     for season in seasons:
-        for rnd in range(1, 23):
+        # Build the list of rounds from the official event schedule so the
+        # function adapts to seasons with a varying number of races.
+        try:
+            schedule = fastf1.get_event_schedule(season)
+            rounds = schedule["RoundNumber"].dropna().unique()
+        except Exception:
+            # Skip the season entirely if the schedule cannot be retrieved
+            continue
+        for rnd in sorted(rounds):
+            rnd = int(rnd)
             try:
+                # Skip the round if data is missing (e.g. cancelled races)
                 # Race session
                 session = fastf1.get_session(season, rnd, 'R')
                 session.load()


### PR DESCRIPTION
## Summary
- iterate over rounds returned by `fastf1.get_event_schedule` when loading historical data
- skip entire season if event schedule can't be retrieved and gracefully skip cancelled rounds
- mention dynamic schedule handling in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683c05ebb5088331a2e82893b37e3836