### PR TITLE
Add championship standings and circuit metadata features

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,10 +12,12 @@ This project uses historical Formula 1 data from the 2020-2025 seasons to build 
 - Team strength assessment
 - Qualifying position influence
 - Driver experience factors
-- Circuit-specific performance patterns
- - Weather conditions and average overtakes metrics derived from
-   historical overtake statistics (`overtake_stats.csv`)
-- Best qualifying and practice session times
+ - Circuit-specific performance patterns
+  - Weather conditions and average overtakes metrics derived from
+    historical overtake statistics (`overtake_stats.csv`)
+ - Best qualifying and practice session times
+ - Championship standings sourced via FastF1/Ergast
+ - Circuit metadata such as track length
 
 The system handles team changes for 2025 (like Hamilton moving to Ferrari) and accommodates rookies through team performance metrics.
 
@@ -78,7 +80,9 @@ This visualization shows:
    - Circuit-specific indicators
    - Weather measurements and average overtakes derived from
      `overtake_stats.csv`
-   - Qualifying and practice session times
+    - Qualifying and practice session times
+    - Championship standings via FastF1/Ergast
+    - Circuit metadata such as track length
 
 3. **Machine Learning Model**
 


### PR DESCRIPTION
## Summary
- engineer championship standing metrics and circuit length
- extend feature lists for training and prediction
- default to zero standings when predicting
- document new championship and circuit features in ReadMe

## Testing
- `python -m py_compile race_predictor.py`

------
https://chatgpt.com/codex/tasks/task_b_683c05fdf3d48331beaa39ad332e789e