### PR TITLE
Improve cleansing for predictions

### DIFF
--- a/race_predictor.py
+++ b/race_predictor.py
@@ -203,6 +203,25 @@ GRAND_PRIX_LIST = [
 ]
 
 
+def _clean_historical_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a cleaned historical dataset for model training.
+
+    This removes duplicated driver entries per race and clips grid/finish
+    positions to the valid range of 1-20. Rows without a driver number are
+    dropped as they cannot be matched to future events.
+    """
+    if df.empty:
+        return df
+
+    df = df.drop_duplicates(subset=["Season", "RaceNumber", "DriverNumber"])
+    df = df[df["DriverNumber"].notna()]
+    df["Position"] = pd.to_numeric(df["Position"], errors="coerce")
+    df["GridPosition"] = pd.to_numeric(df["GridPosition"], errors="coerce")
+    df["Position"] = df["Position"].clip(1, 20)
+    df["GridPosition"] = df["GridPosition"].clip(1, 20)
+    return df
+
+
 def _load_historical_data(seasons, overtake_map=None):
     if overtake_map is None:
         overtake_map = OVERTAKE_AVERAGES
@@ -578,8 +597,11 @@ def _prepare_features(full_data, base_cols, team_encoder=None, circuit_encoder=N
     # ``0`` to keep shapes consistent during prediction.
     for col in base_cols:
         if col not in full_data.columns:
-            full_data[col] = 0
-        full_data[col] = pd.to_numeric(full_data[col], errors="coerce").fillna(0)
+            full_data[col] = np.nan
+        full_data[col] = pd.to_numeric(full_data[col], errors="coerce")
+    # Fill remaining NaNs with the column median to reduce the impact of
+    # missing values on the model while keeping feature scales realistic.
+    full_data[base_cols] = full_data[base_cols].fillna(full_data[base_cols].median())
 
     if team_encoder is None:
         team_encoder = OneHotEncoder(handle_unknown='ignore', sparse_output=False)
@@ -678,7 +700,7 @@ def predict_race(grand_prix, year=2025, export_details=False, debug=False, compu
             print(f"Could not compute overtakes for {grand_prix}: {err}")
 
     race_data = _load_historical_data(seasons, overtake_map)
-    race_data = race_data.reset_index(drop=True)
+    race_data = _clean_historical_data(race_data).reset_index(drop=True)
     # Ensure DriverNumber is numeric for consistent merging
     race_data['DriverNumber'] = pd.to_numeric(race_data['DriverNumber'], errors='coerce')
     qual_results = None


### PR DESCRIPTION
## Summary
- implement `_clean_historical_data` to drop duplicates and clip invalid grid/finish values
- replace zero imputation with median filling in `_prepare_features`
- clean historical data before training

## Testing
- `python -m py_compile race_predictor.py export_race_details.py generate_2025_data.py estimate_overtakes.py webapp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c12b258d883319e0a346a46274a3a