### PR TITLE
Fix grid ranking update logic

### DIFF
--- a/race_predictor.py
+++ b/race_predictor.py
@@ -293,8 +293,11 @@ def _load_historical_data(seasons, overtake_map=None):
                         on='DriverNumber',
                         how='left'
                     )
-                    # Use Q3 ranking for grid, falling back to qualifying order if needed.
-                    results['GridPosition'] = results['GridFromQ3'].fillna(results['QualiPosition'])
+                    # Preserve the official GridPosition from the race result.
+                    # Only fill missing values using qualifying information.
+                    if 'GridPosition' in results.columns:
+                        results['GridPosition'] = results['GridPosition'].fillna(results['QualiPosition'])
+                        results['GridPosition'] = results['GridPosition'].fillna(results['GridFromQ3'])
                 except Exception:
                     results['BestQualiTime'] = np.nan
                     results['QualiPosition'] = np.nan


### PR DESCRIPTION
## Summary
- keep official `GridPosition` from race results
- only fill missing grid spots using qualifying data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683c1d9cc5fc8331b810f76122addc0e