### PR TITLE
Reset rolling averages per season

### DIFF
--- a/race_predictor.py
+++ b/race_predictor.py
@@ -413,28 +413,31 @@ def _engineer_features(full_data):
 
     full_data.sort_values(['Season', 'RaceNumber'], inplace=True)
     full_data['ExperienceCount'] = full_data.groupby('DriverNumber').cumcount() + 1
+    full_data['RaceIdxInSeason'] = (
+        full_data.groupby(['Season', 'DriverNumber']).cumcount() + 1
+    )
     full_data['RecentAvgPosition'] = (
-        full_data.groupby('DriverNumber')['Position']
+        full_data.groupby(['DriverNumber', 'Season'])['Position']
         .apply(lambda s: s.shift().rolling(window=5, min_periods=1).mean())
-        .reset_index(level=0, drop=True)
+        .reset_index(level=[0, 1], drop=True)
     )
     full_data['RecentAvgPosition'] = full_data['RecentAvgPosition'].fillna(full_data['Position'].mean())
     full_data['Recent3AvgFinish'] = (
-        full_data.groupby('DriverNumber')['Position']
+        full_data.groupby(['DriverNumber', 'Season'])['Position']
         .apply(lambda s: s.shift().rolling(window=3, min_periods=1).mean())
-        .reset_index(level=0, drop=True)
+        .reset_index(level=[0, 1], drop=True)
     )
     full_data['Recent3AvgFinish'] = full_data['Recent3AvgFinish'].fillna(full_data['Position'].mean())
     full_data['Recent5AvgFinish'] = (
-        full_data.groupby('DriverNumber')['Position']
+        full_data.groupby(['DriverNumber', 'Season'])['Position']
         .apply(lambda s: s.shift().rolling(window=5, min_periods=1).mean())
-        .reset_index(level=0, drop=True)
+        .reset_index(level=[0, 1], drop=True)
     )
     full_data['Recent5AvgFinish'] = full_data['Recent5AvgFinish'].fillna(full_data['Position'].mean())
     full_data['RecentAvgPoints'] = (
-        full_data.groupby('DriverNumber')['Points']
+        full_data.groupby(['DriverNumber', 'Season'])['Points']
         .apply(lambda s: s.shift().rolling(window=5, min_periods=1).mean())
-        .reset_index(level=0, drop=True)
+        .reset_index(level=[0, 1], drop=True)
     )
     full_data['RecentAvgPoints'] = full_data['RecentAvgPoints'].fillna(0)
 
@@ -446,19 +449,19 @@ def _engineer_features(full_data):
     full_data = pd.merge(full_data, driver_track, on=['DriverNumber', 'Circuit'], how='left')
 
     full_data['TeamRecentQuali'] = (
-        full_data.groupby('HistoricalTeam')['QualiPosition']
+        full_data.groupby(['HistoricalTeam', 'Season'])['QualiPosition']
         .apply(lambda s: s.shift().rolling(window=5, min_periods=1).mean())
-        .reset_index(level=0, drop=True)
+        .reset_index(level=[0, 1], drop=True)
     )
     full_data['TeamRecentFinish'] = (
-        full_data.groupby('HistoricalTeam')['Position']
+        full_data.groupby(['HistoricalTeam', 'Season'])['Position']
         .apply(lambda s: s.shift().rolling(window=5, min_periods=1).mean())
-        .reset_index(level=0, drop=True)
+        .reset_index(level=[0, 1], drop=True)
     )
     full_data['TeamReliability'] = (
-        full_data.groupby('HistoricalTeam')['DidNotFinish']
+        full_data.groupby(['HistoricalTeam', 'Season'])['DidNotFinish']
         .apply(lambda s: s.shift().rolling(window=5, min_periods=1).sum())
-        .reset_index(level=0, drop=True)
+        .reset_index(level=[0, 1], drop=True)
     )
     full_data['TeamRecentQuali'] = full_data['TeamRecentQuali'].fillna(full_data['QualiPosition'].mean())
     full_data['TeamRecentFinish'] = full_data['TeamRecentFinish'].fillna(full_data['Position'].mean())


### PR DESCRIPTION
## Summary
- reset driver and team rolling windows at the start of each season
- add `RaceIdxInSeason` helper column

## Testing
- `python -m py_compile race_predictor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c37577fc48331ac8cb96bc606879c