### PR TITLE
Add qualifying gap feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains tools to predict the outcome of Formula&nbsp;1 races in
 The model is trained on event data from the 2020‑2025 seasons. For each race it collects:
 
 1. **Driver and team results** from FastF1 with fallbacks to the Ergast API.
-2. **Qualifying and practice times** for each driver.
+2. **Qualifying and practice times** for each driver, including the time gap to the next fastest qualifier.
 3. **Weather data** (air temperature, track temperature, rainfall).
 4. **Average overtakes** per circuit calculated with `estimate_overtakes.py`.
 5. **Championship standings and circuit metadata** such as track length.


### PR DESCRIPTION
## Summary
- compute time difference to the next fastest qualifier in training data
- expose `DeltaToNext` feature for prediction runs
- include new feature in the list of model columns
- document gap feature in README

## Testing
- `python -m py_compile *.py`
- `python race_predictor.py` *(fails: ModuleNotFoundError: No module named 'fastf1')*

------
https://chatgpt.com/codex/tasks/task_b_683cadd6f2948331b5fb876a5f0879ce