### PR TITLE
Improve weather predictions using API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains tools to predict the outcome of Formula&nbsp;1 races in
 - **Race prediction** using a single XGBoost model.
 - **Automatic team and driver handling** for 2025 line‑ups, including rookies.
 - **Weather and circuit statistics** such as air/track temperature and estimated overtakes per circuit.
+- **Live weather forecasts** blended with historical averages when an `OPENWEATHER_API_KEY` is provided.
 - **Historical performance metrics** like driver experience, recent form and track specific results.
 - **Sprint form** including finishing positions from sprint races when applicable.
 - **Streamlit web interface** to quickly run predictions for any Grand Prix.
@@ -39,6 +40,7 @@ Install the dependencies with:
 ```bash
 pip install fastf1 pandas numpy scikit-learn matplotlib seaborn optuna xgboost streamlit
 ```
+If you want live weather predictions, set the `OPENWEATHER_API_KEY` environment variable to your OpenWeatherMap API key.
 
 ## Running Predictions
 


### PR DESCRIPTION
## Summary
- integrate OpenWeatherMap forecast via new `fetch_weather` function
- blend real-time weather with historical averages in `predict_race`
- document how to enable the feature in README

## Testing
- `python -m py_compile race_predictor.py`
- `python -m py_compile export_race_details.py generate_2025_data.py estimate_overtakes.py webapp.py`


------
https://chatgpt.com/codex/tasks/task_b_683cb716efd0833190d44be7f3084b96