### PR TITLE
Use XGBRanker for race predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ Downloads FP3, qualifying and race information for every scheduled event in 2025
 
 ## Evaluation Metrics
 
-The training routine optimises mean absolute error on finishing position.
-During training and hold-out evaluation the script also reports:
+The training routine optimises **Spearman rank correlation** on finishing order
+using ``XGBRanker`` with a pairwise ranking objective. During training and
+hold-out evaluation the script also reports:
 
 - **Spearman rank correlation** between predicted and actual results.
 - **Top 1 accuracy** – percentage of races where the predicted winner matches the real winner.


### PR DESCRIPTION
## Summary
- switch from `XGBRegressor` to `XGBRanker`
- compute groups per race for ranking model
- optimise Spearman correlation during training
- print CV Spearman score
- document ranking objective in README

## Testing
- `python -m py_compile race_predictor.py`
- `python -m py_compile export_race_details.py generate_2025_data.py estimate_overtakes.py webapp.py`

------
https://chatgpt.com/codex/tasks/task_b_683cb984322c8331b5a3719bcbbe9f84