### PR TITLE
Add team tier encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains tools to predict the outcome of Formula&nbsp;1 races in
 - **Live weather forecasts** blended with historical averages when an `OPENWEATHER_API_KEY` is provided.
 - **Historical performance metrics** like driver experience, recent form and track specific results.
 - **Sprint form** including finishing positions from sprint races when applicable.
+- **Team tier categories** derived from the previous season's constructor points.
 - **Streamlit web interface** to quickly run predictions for any Grand Prix.
 - **Data export utilities** to save FP3, qualifying, sprint and race session information.
 - **Rank-based metrics** showing podium accuracy and Spearman correlation.


### PR DESCRIPTION
## Summary
- map constructors into quartile-based tiers using last year's points
- one-hot encode `TeamTier` instead of lumping into a single `Other`
- document team tier feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python race_predictor.py` *(fails: ModuleNotFoundError: No module named 'fastf1')*

------
https://chatgpt.com/codex/tasks/task_b_683cbc6839008331b776644953b8fd97