### PR TITLE
Switch prints to logging

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -1,5 +1,6 @@
 import os
 import warnings
+import logging
 
 import fastf1
 import requests
@@ -8,6 +9,8 @@ import pandas as pd
 from sklearn.preprocessing import OneHotEncoder
 
 from export_race_details import _fetch_session_data
+
+logger = logging.getLogger(__name__)
 
 warnings.filterwarnings('ignore')
 
@@ -254,7 +257,7 @@ def fetch_weather(circuit: str, api_key: str | None = None) -> dict | None:
             rain = float(np.max(pops)) if pops else 0.0
             return {"ForecastAirTemp": air, "ForecastPrecipChance": rain}
     except Exception as err:  # pragma: no cover - network call
-        print(f"⚠️ Failed to fetch weather: {err}")
+        logger.warning("Failed to fetch weather: %s", err)
     return None
 
 

--- a/estimate_overtakes.py
+++ b/estimate_overtakes.py
@@ -1,5 +1,6 @@
 import os
 import statistics
+import logging
 from typing import Iterable, List
 
 import numpy as np
@@ -10,6 +11,8 @@ except ImportError as exc:
     raise SystemExit("fastf1 is required to run this script. Install via 'pip install fastf1'.") from exc
 
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def _count_position_changes(laps: pd.DataFrame) -> int:
@@ -93,7 +96,9 @@ def average_overtakes(grand_prix: str, years: Iterable[int]) -> float:
         try:
             counts.append(count_overtakes(yr, grand_prix))
         except Exception as err:
-            print(f"⚠️ Failed to process {yr} {grand_prix}: {err}")
+            logger.warning(
+                "Failed to process %s %s: %s", yr, grand_prix, err
+            )
     if not counts:
         raise RuntimeError("No races processed")
 
@@ -111,7 +116,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     avg = average_overtakes(args.grand_prix, args.years)
-    print(f"📈 Weighted average overtakes at {args.grand_prix}: {avg:.1f}")
+    logger.info(
+        "Weighted average overtakes at %s: %.1f", args.grand_prix, avg
+    )
 
     # Update or create the CSV used by the prediction model
     out_file = "overtake_stats.csv"

--- a/generate_2025_data.py
+++ b/generate_2025_data.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import pandas as pd
 
 try:
@@ -7,6 +8,8 @@ except ImportError as exc:
     raise SystemExit("fastf1 is required to run this script. Install via 'pip install fastf1'.") from exc
 
 from export_race_details import _fetch_session_data
+
+logger = logging.getLogger(__name__)
 
 def export_full_season(year: int = 2025, output_file: str = "prediction_data_race_2025.csv") -> str:
     """Collect FP3, qualifying and race data for all events in a season."""
@@ -25,7 +28,9 @@ def export_full_season(year: int = 2025, output_file: str = "prediction_data_rac
                 df['EventName'] = gp
                 data_frames.append(df)
             except Exception as err:
-                print(f"⚠️ Failed to load {year} {gp} {code}: {err}")
+                logger.warning(
+                    "Failed to load %d %s %s: %s", year, gp, code, err
+                )
 
     if not data_frames:
         raise RuntimeError("No data collected for season")
@@ -36,4 +41,4 @@ def export_full_season(year: int = 2025, output_file: str = "prediction_data_rac
 
 if __name__ == "__main__":
     path = export_full_season()
-    print(f"✅ Saved full season data to {path}")
+    logger.info("Saved full season data to %s", path)

--- a/race_predictor.py
+++ b/race_predictor.py
@@ -1,6 +1,13 @@
+import logging
+
 from predictor import predict_race
 from data_utils import GRAND_PRIX_LIST
 
+logger = logging.getLogger(__name__)
+
 if __name__ == '__main__':
     res = predict_race('Chinese Grand Prix', year=2025, export_details=True, debug=False)
-    print(res[['Driver', 'Team', 'Grid', 'Final_Position']].head())
+    logger.info(
+        "\n%s",
+        res[['Driver', 'Team', 'Grid', 'Final_Position']].head(),
+    )


### PR DESCRIPTION
## Summary
- use Python's `logging` module instead of prints throughout the repo
- show runtime metrics and warnings via logger

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cc2450b648331813bc3d0b7773d1b