### PR TITLE
Fix missing os import

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -1,4 +1,5 @@
 from os import makedirs
+import os
 import logging
 from warnings import filterwarnings
 


### PR DESCRIPTION
## Summary
- import `os` in data_utils to use `os.path` and `os.getenv`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683ccc1284c883319e6c9c64a6626bc2