### PR TITLE
Fix Points default in feature engineering

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -454,7 +454,10 @@ def _engineer_features(full_data):
     full_data['Rainfall'] = pd.to_numeric(full_data.get('Rainfall'), errors='coerce')
     full_data['WeightedAvgOvertakes'] = pd.to_numeric(full_data.get('WeightedAvgOvertakes'), errors='coerce')
     # Ensure Points column exists for feature engineering
-    full_data['Points'] = pd.to_numeric(full_data.get('Points'), errors='coerce').fillna(0)
+    full_data['Points'] = pd.to_numeric(
+        full_data.get('Points', pd.Series(nan, index=full_data.index)),
+        errors='coerce'
+    ).fillna(0)
     full_data['BestQualiTime'] = pd.to_numeric(full_data.get('BestQualiTime'), errors='coerce')
     full_data['FP3BestTime'] = pd.to_numeric(full_data.get('FP3BestTime'), errors='coerce')
     full_data['FP3LongRunTime'] = pd.to_numeric(full_data.get('FP3LongRunTime'), errors='coerce')


### PR DESCRIPTION
## Summary
- fix `_engineer_features` when `Points` column is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683cd621141083319bf8bc70ce55a188