### PR TITLE
Fix KeyError when encoding features

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -827,6 +827,8 @@ def _prepare_features(
     if "Circuit" not in full_data.columns:
         full_data["Circuit"] = "Unknown Circuit"
     for col in base_cols:
+        if col not in full_data.columns:
+            full_data[col] = nan
         full_data[col] = to_numeric(full_data[col], errors="coerce")
     full_data[base_cols] = full_data[base_cols].fillna(full_data[base_cols].median())
     team_cols = [f"TeamTier_{i}" for i in range(4)]


### PR DESCRIPTION
## Summary
- handle missing columns when converting data to numeric in `_prepare_features`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683ce2eab2888331908693cdfd230eeb