### PR TITLE
Fix pandas conversion for FastF1 results

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -36,7 +36,9 @@ def _get_event_drivers(year: int, grand_prix: str) -> pd.DataFrame:
     try:
         session.load(telemetry=False, laps=False, weather=False)
         if hasattr(session, "results") and not session.results.empty:
-            info = session.results[["DriverNumber", "Abbreviation", "FullName", "TeamName"]].copy()
+            info = pd.DataFrame(session.results)[
+                ["DriverNumber", "Abbreviation", "FullName", "TeamName"]
+            ].copy()
             info.rename(columns={"TeamName": "Team"}, inplace=True)
             return info
     except Exception:
@@ -89,9 +91,18 @@ def _get_qualifying_results(year: int, grand_prix: str) -> pd.DataFrame:
     round_number = int(match.iloc[0]["RoundNumber"])
     session = get_session(year, round_number, "Q")
     session.load()
-    q_res = session.results[[
-        "DriverNumber", "Abbreviation", "FullName", "TeamName", "Position", "Q1", "Q2", "Q3"
-    ]].copy()
+    q_res = pd.DataFrame(session.results)[
+        [
+            "DriverNumber",
+            "Abbreviation",
+            "FullName",
+            "TeamName",
+            "Position",
+            "Q1",
+            "Q2",
+            "Q3",
+        ]
+    ].copy()
 
     def _to_seconds(val):
         if pd.isna(val):
@@ -321,7 +332,9 @@ def _load_historical_data(seasons, overtake_map=None, max_round_by_season=None):
             try:
                 session = get_session(season, rnd, 'R')
                 session.load()
-                results = session.results[['DriverNumber', 'Position', 'Points', 'GridPosition', 'Status']]
+                results = pd.DataFrame(session.results)[
+                    ['DriverNumber', 'Position', 'Points', 'GridPosition', 'Status']
+                ]
                 results['Season'] = season
                 results['RaceNumber'] = rnd
                 results['Circuit'] = session.event['EventName']
@@ -339,7 +352,9 @@ def _load_historical_data(seasons, overtake_map=None, max_round_by_season=None):
                 try:
                     q_session = get_session(season, rnd, 'Q')
                     q_session.load()
-                    q_results = q_session.results[['DriverNumber', 'Position', 'Q1', 'Q2', 'Q3']]
+                    q_results = pd.DataFrame(q_session.results)[
+                        ['DriverNumber', 'Position', 'Q1', 'Q2', 'Q3']
+                    ]
 
                     def _best_time(row):
                         times = []
@@ -398,7 +413,9 @@ def _load_historical_data(seasons, overtake_map=None, max_round_by_season=None):
                 try:
                     sprint_session = get_session(season, rnd, 'S')
                     sprint_session.load()
-                    sprint_res = sprint_session.results[['DriverNumber', 'Position']].rename(
+                    sprint_res = pd.DataFrame(sprint_session.results)[
+                        ['DriverNumber', 'Position']
+                    ].rename(
                         columns={'Position': 'SprintFinish'}
                     )
                     results = results.merge(sprint_res, on='DriverNumber', how='left')
@@ -418,7 +435,7 @@ def _add_driver_team_info(full_data, seasons):
             first_race = schedule.iloc[0]['RoundNumber']
             session = get_session(season, first_race, 'R')
             session.load()
-            for _, row in session.results.iterrows():
+            for _, row in pd.DataFrame(session.results).iterrows():
                 driver_number = row['DriverNumber']
                 driver_team = row['TeamName']
                 seasons_drivers.setdefault(season, {})[driver_number] = driver_team


### PR DESCRIPTION
## Summary
- ensure FastF1 `SessionResults` objects are cast to pandas `DataFrame`
- handle race, qualifying and sprint results
- update driver/team helper to iterate over a pandas DataFrame

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683cecd1204c833181e3e4b605a797c7