### PR TITLE
Fix best_iteration property for XGBRanker

### DIFF
--- a/model_utils.py
+++ b/model_utils.py
@@ -171,7 +171,13 @@ def _train_model(features, target, cv, debug=False):
         early_stopping_rounds=20,
         verbose=False,
     )
-    best_iter = model.best_iteration_
+    best_iter = None
+    for attr in ("best_iteration", "best_iteration_", "best_ntree_limit"):
+        if hasattr(model, attr):
+            best_iter = getattr(model, attr)
+            break
+    if best_iter is None:
+        best_iter = model.n_estimators
 
     model = XGBRanker(
         objective="rank:pairwise",


### PR DESCRIPTION
## Summary
- support several XGBRanker best iteration attribute names in `model_utils._train_model`

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683cf0ef05408331a16bda9beb96876e