### PR TITLE
Add per-year overtake counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you want live weather predictions, set the `OPENWEATHER_API_KEY` environment 
    python estimate_overtakes.py "Monaco Grand Prix" 2022 2023 2024
    ```
 
-   Calculates the weighted average number of genuine overtakes for the circuit and updates `overtake_stats.csv`.
+   Calculates the weighted average number of genuine overtakes for the circuit and updates `overtake_stats.csv`. Use `--per-year` to also display the count for each season.
 
 5. **Generate full season data**
 

--- a/estimate_overtakes.py
+++ b/estimate_overtakes.py
@@ -1,7 +1,7 @@
 import os
 import statistics
 import logging
-from typing import Iterable, List
+from typing import Iterable, List, Dict
 
 import numpy as np
 
@@ -107,13 +107,38 @@ def average_overtakes(grand_prix: str, years: Iterable[int]) -> float:
     return float(weighted)
 
 
+def overtakes_per_year(grand_prix: str, years: Iterable[int]) -> Dict[int, int]:
+    """Return the overtake count for each season."""
+    counts: Dict[int, int] = {}
+    for yr in years:
+        try:
+            counts[yr] = count_overtakes(yr, grand_prix)
+        except Exception as err:
+            logger.warning("Failed to process %s %s: %s", yr, grand_prix, err)
+    if not counts:
+        raise RuntimeError("No races processed")
+    return counts
+
+
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Estimate race overtakes using lap position changes")
     parser.add_argument("grand_prix", help="Grand Prix name, e.g. 'Monaco'")
     parser.add_argument("years", nargs="+", type=int, help="List of seasons to average")
+    parser.add_argument(
+        "--per-year",
+        action="store_true",
+        help="Display the overtakes for each supplied year",
+    )
     args = parser.parse_args()
+
+    if args.per_year:
+        per_year = overtakes_per_year(args.grand_prix, args.years)
+        for yr in sorted(per_year):
+            logger.info(
+                "Overtakes at %s %d: %d", args.grand_prix, yr, per_year[yr]
+            )
 
     avg = average_overtakes(args.grand_prix, args.years)
     logger.info(


### PR DESCRIPTION
## Summary
- calculate overtake counts per season
- expose `--per-year` CLI option for `estimate_overtakes.py`
- document the new option in the README

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_b_683d82f016388331ad786789e9c9c6c4