### PR TITLE
Handle team changes across rounds

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -438,29 +438,60 @@ def _load_historical_data(seasons, overtake_map=None, max_round_by_season=None):
 
 
 def _add_driver_team_info(full_data, seasons):
-    seasons_drivers = {}
+    """Attach driver team information using historical race results.
+
+    Driver line-ups can change mid-season.  To capture this the function
+    collects the team for every race in ``seasons`` and, for each row in
+    ``full_data``, assigns the team from the latest race at or before that
+    event.
+    """
+
+    season_history = {}
+
     for season in seasons:
         try:
             schedule = get_event_schedule(season)
-            first_race = schedule.iloc[0]['RoundNumber']
-            session = get_session(season, first_race, 'R')
-            session.load()
-            df = pd.DataFrame(session.results.values, columns=session.results.columns)
-            for _, row in df.iterrows():
-                driver_number = row['DriverNumber']
-                driver_team = row['TeamName']
-                seasons_drivers.setdefault(season, {})[driver_number] = driver_team
+            rounds = (
+                schedule["RoundNumber"].dropna().astype(int).unique().tolist()
+            )
         except Exception:
             continue
 
-    full_data['HistoricalTeam'] = None
+        race_map = {}
+        for rnd in sorted(rounds):
+            try:
+                session = get_session(season, rnd, "R")
+                session.load()
+                df = pd.DataFrame(
+                    session.results.values, columns=session.results.columns
+                )
+                race_map[rnd] = df.set_index("DriverNumber")["TeamName"].to_dict()
+            except Exception:
+                continue
+
+        if race_map:
+            season_history[season] = race_map
+
+    full_data["HistoricalTeam"] = None
     for idx, row in full_data.iterrows():
-        season = row['Season']
-        driver_num = row['DriverNumber']
-        if season in seasons_drivers and driver_num in seasons_drivers[season]:
-            full_data.at[idx, 'HistoricalTeam'] = seasons_drivers[season][driver_num]
-        else:
-            full_data.at[idx, 'HistoricalTeam'] = 'Unknown Team'
+        season = row["Season"]
+        driver_num = row["DriverNumber"]
+        race_num = row.get("RaceNumber")
+
+        team = None
+        history = season_history.get(season)
+        if history and race_num is not None:
+            candidates = [r for r in history.keys() if r <= int(race_num)]
+            if candidates:
+                last_round = max(candidates)
+                team = history[last_round].get(driver_num)
+
+        if team is None and history:
+            first_round = min(history.keys())
+            team = history[first_round].get(driver_num)
+
+        full_data.at[idx, "HistoricalTeam"] = team if team is not None else "Unknown Team"
+
     return full_data
 
 

--- a/tests/test_driver_team_info.py
+++ b/tests/test_driver_team_info.py
@@ -1,0 +1,34 @@
+import pytest
+pd = pytest.importorskip("pandas")
+from data_utils import _add_driver_team_info
+
+class FakeSession:
+    def __init__(self, df):
+        self.results = df
+    def load(self):
+        pass
+
+
+def test_driver_team_assignment_across_rounds(monkeypatch):
+    def fake_get_event_schedule(year):
+        return pd.DataFrame({'RoundNumber': [1, 2, 3]})
+
+    def fake_get_session(year, rnd, kind):
+        mapping = {
+            1: pd.DataFrame({'DriverNumber': [1, 2], 'TeamName': ['A', 'B']}),
+            2: pd.DataFrame({'DriverNumber': [1, 2], 'TeamName': ['A', 'B']}),
+            3: pd.DataFrame({'DriverNumber': [1, 2], 'TeamName': ['C', 'B']}),
+        }
+        return FakeSession(mapping[rnd])
+
+    monkeypatch.setattr('data_utils.get_event_schedule', fake_get_event_schedule)
+    monkeypatch.setattr('data_utils.get_session', fake_get_session)
+
+    df = pd.DataFrame({
+        'Season': [2024, 2024, 2024, 2024, 2024, 2024],
+        'RaceNumber': [1, 1, 2, 2, 3, 3],
+        'DriverNumber': [1, 2, 1, 2, 1, 2],
+    })
+
+    result = _add_driver_team_info(df.copy(), [2024])
+    assert list(result['HistoricalTeam']) == ['A', 'B', 'A', 'B', 'C', 'B']


### PR DESCRIPTION
## Summary
- gather driver-team mappings for every race
- pick the latest available race when filling `HistoricalTeam`
- add regression test covering team assignment across rounds

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683d9347bc08833186c68ca057dc3be4