### PR TITLE
Add yearly overtake stats

### DIFF
--- a/estimate_overtakes.py
+++ b/estimate_overtakes.py
@@ -145,16 +145,18 @@ if __name__ == "__main__":
         "Weighted average overtakes at %s: %.1f", args.grand_prix, avg
     )
 
-    # Update or create the CSV used by the prediction model
     out_file = "overtake_stats.csv"
     try:
         df = pd.read_csv(out_file)
     except Exception:
-        df = pd.DataFrame(columns=["Circuit", "WeightedAvgOvertakes"])
+        df = pd.DataFrame(columns=["Circuit"])
 
     df = df[df["Circuit"] != args.grand_prix]
-    df = pd.concat(
-        [df, pd.DataFrame({"Circuit": [args.grand_prix], "WeightedAvgOvertakes": [avg]})],
-        ignore_index=True,
-    )
+
+    per_year = overtakes_per_year(args.grand_prix, args.years)
+    row = {"Circuit": args.grand_prix}
+    for yr, val in per_year.items():
+        row[f"Overtakes_{yr}"] = val
+
+    df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
     df.to_csv(out_file, index=False)

--- a/overtake_stats.csv
+++ b/overtake_stats.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f65e73b650a1d5853db55e0385bbc5a513ec04375220205d9a34e28c9433f1e
-size 69
+oid sha256:18c15f539036dc0a2af92c23178b89f5a3a226f8370aef0f5567a852287e946e
+size 65

--- a/pipeline.py
+++ b/pipeline.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from sklearn.metrics import mean_absolute_error
 
 from export_race_details import export_race_details
-from estimate_overtakes import average_overtakes
+from estimate_overtakes import overtakes_per_year
 from data_utils import (
     _load_historical_data,
     _clean_historical_data,
@@ -78,8 +78,8 @@ def predict_race(
     if compute_overtakes:
         try:
             years_for_avg = list(range(max(2022, year - 3), year))
-            avg = average_overtakes(grand_prix, years_for_avg)
-            overtake_map[grand_prix] = avg
+            per_year = overtakes_per_year(grand_prix, years_for_avg)
+            overtake_map.setdefault(grand_prix, {}).update(per_year)
         except Exception as err:
             logger.warning(
                 "Could not compute overtakes for %s: %s", grand_prix, err
@@ -211,7 +211,7 @@ def predict_race(
         default_air, default_track, default_rain = hist_air, hist_track, hist_rain
         default_fp3 = race_data['FP3BestTime'].mean()
         default_fp3_long = race_data['FP3LongRunTime'].mean()
-    default_overtake = race_data['WeightedAvgOvertakes'].mean()
+    default_overtake = race_data['Overtakes_CurrentYear'].mean()
 
     try:
         from fastf1.circuit_info import get_circuit_info
@@ -432,7 +432,7 @@ def predict_race(
             'AirTemp': default_air,
             'TrackTemp': default_track,
             'Rainfall': default_rain,
-            'WeightedAvgOvertakes': default_overtake,
+            'Overtakes_CurrentYear': default_overtake,
             'Team': d['Team'],
             'FullName': d['FullName'],
             'Abbreviation': d['Abbreviation']
@@ -735,7 +735,7 @@ def _build_pred_df(race_data, grand_prix, year, this_race_number, event_month, e
         default_air, default_track, default_rain = hist_air, hist_track, hist_rain
         default_fp3 = race_data["FP3BestTime"].mean()
         default_fp3_long = race_data["FP3LongRunTime"].mean()
-    default_overtake = race_data["WeightedAvgOvertakes"].mean()
+    default_overtake = race_data["Overtakes_CurrentYear"].mean()
 
     try:
         from fastf1.circuit_info import get_circuit_info
@@ -964,7 +964,7 @@ def _build_pred_df(race_data, grand_prix, year, this_race_number, event_month, e
                 "AirTemp": default_air,
                 "TrackTemp": default_track,
                 "Rainfall": default_rain,
-                "WeightedAvgOvertakes": default_overtake,
+                "Overtakes_CurrentYear": default_overtake,
                 "Team": d["Team"],
                 "FullName": d["FullName"],
                 "Abbreviation": d["Abbreviation"],

--- a/tests/test_encode_features.py
+++ b/tests/test_encode_features.py
@@ -36,7 +36,7 @@ def test_encoding_unknown_circuit_and_team():
         "TeamTier_0": [0], "TeamTier_1": [0], "TeamTier_2": [1], "TeamTier_3": [0],
         "CircuitLength": [5.424], "NumCorners": [19], "DRSZones": [2],
         "StdLapTime": [98.5], "IsStreet": [0], "DownforceLevel": [1],
-        "WeightedAvgOvertakes": [30.0],
+        "Overtakes_CurrentYear": [30.0],
         "HistoricalTeam": ["ImaginaryRacers"],
         "Circuit": ["Neverland GP"],
     })


### PR DESCRIPTION
## Summary
- capture overtakes per year instead of one average
- use `Overtakes_CurrentYear` feature in pipeline and data utils
- adjust overtake stats exporter
- update tests and sample `overtake_stats.csv`

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_683dd2f3e38c8331b564d5b597c69336