### PR TITLE
Add circuit embeddings using PCA

### DIFF
--- a/tests/test_encode_features.py
+++ b/tests/test_encode_features.py
@@ -43,6 +43,7 @@ def test_encoding_unknown_circuit_and_team():
         "CircuitLength": [5.424], "NumCorners": [19], "DRSZones": [2],
         "StdLapTime": [98.5], "IsStreet": [0], "DownforceLevel": [1],
         "Overtakes_CurrentYear": [30.0],
+        "CircuitEmbed1": [0.0], "CircuitEmbed2": [0.0],
         "HistoricalTeam": ["ImaginaryRacers"],
         "Circuit": ["Neverland GP"],
     })


### PR DESCRIPTION
## Summary
- compute PCA based embeddings for circuits
- include embedding columns in default race features
- adjust encode feature tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_b_683deb27ccb48331858ffbf740d19874