### PR TITLE
Fix pipeline prediction sprint finish fallback

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1201,6 +1201,18 @@ def _build_pred_df(
     if pred_df.empty:
         raise ValueError(f"No driver data available for {year} {grand_prix}")
 
+    # Fallback averages for sprint finish positions
+    if "SprintFinish" in race_data.columns:
+        driver_sprint_mean = (
+            race_data.groupby("DriverNumber")["SprintFinish"].mean().dropna().to_dict()
+        )
+        team_sprint_mean = (
+            race_data.groupby("HistoricalTeam")["SprintFinish"].mean().dropna().to_dict()
+        )
+    else:
+        driver_sprint_mean = {}
+        team_sprint_mean = {}
+
     pred_df["GridPosition"] = (
         pd.to_numeric(pred_df["GridPosition"], errors="coerce").fillna(20)
     )


### PR DESCRIPTION
## Summary
- define fallback driver and team sprint finish averages inside the prediction builder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e145984b88331b70d49311d7ca9ea