### PR TITLE
Fix grid position assignment from qualifying data

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -494,15 +494,10 @@ def predict_race(
             dnfs = stats['DriverTrackDNFs']
 
         penalty = int(d.get('Penalty', 0))
-        grid_missed = 0
         if qual_results is not None and 'GridPosition' in d and pd.notna(d['GridPosition']):
-            grid_pos = int(d['GridPosition'])
+            grid_pos = int(d['GridPosition']) + penalty
             best_time = d['BestTime']
-            if d.get('StatusQuali') != 'Q3':
-                grid_pos = 20 + penalty
-                grid_missed = 1
-            else:
-                grid_pos += penalty
+            grid_missed = 1 if grid_pos > 20 else 0
         else:
             grid_pos = 20 + penalty
             best_time = default_best_q
@@ -1099,15 +1094,10 @@ def _build_pred_df(
             dnfs = stats["DriverTrackDNFs"]
 
         penalty = int(d.get("Penalty", 0))
-        grid_missed = 0
         if qual_results is not None and "GridPosition" in d and pd.notna(d["GridPosition"]):
-            grid_pos = int(d["GridPosition"])
+            grid_pos = int(d["GridPosition"]) + penalty
             best_time = d["BestTime"]
-            if d.get("StatusQuali") != "Q3":
-                grid_pos = 20 + penalty
-                grid_missed = 1
-            else:
-                grid_pos += penalty
+            grid_missed = 1 if grid_pos > 20 else 0
         else:
             grid_pos = 20 + penalty
             best_time = default_best_q


### PR DESCRIPTION
## Notes
- Grid positions were incorrectly set to 20 whenever a driver did not reach Q3. That meant predictions always showed the fallback value even when qualifying data was available.
- Now the official grid position is used whenever qualifying results are present and penalties are applied on top. `GridMissed` is only flagged if the final grid number exceeds 20.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e1a451e888331a1433f1acd895b53