### PR TITLE
Handle missing driver numbers with lookup

### DIFF
--- a/driver_lookup.csv
+++ b/driver_lookup.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb971d6e666534f14e9356b83a3f2389c93d82a6c97d90b71984daba437c4793
+size 53

--- a/pipeline.py
+++ b/pipeline.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pickle
 import matplotlib.pyplot as plt
+import csv
 from datetime import datetime
 from sklearn.metrics import mean_absolute_error
 
@@ -259,439 +260,15 @@ def predict_race(
     finish_mae = mean_absolute_error(race_data['Position'], finish_preds_hist)
     train_rank = _rank_metrics(race_data['Position'], finish_preds_hist)
 
-    try:
-        drivers_df = _get_qualifying_results(year, grand_prix)
-        drivers_df = drivers_df[drivers_df['BestTime'].notna()]
-        qual_results = drivers_df.copy()
-    except Exception:
-        drivers_df = _get_event_drivers(year, grand_prix)
-        qual_results = None
-
-    drivers_df['DriverNumber'] = pd.to_numeric(drivers_df['DriverNumber'], errors='coerce')
-
-    try:
-        fp3_results = _get_fp3_results(year, grand_prix)
-        if qual_results is not None:
-            qual_results = qual_results.merge(fp3_results, on='Abbreviation', how='left')
-    except Exception:
-        fp3_results = None
-
-    try:
-        sprint_results = _get_sprint_results(year, grand_prix)
-        has_sprint = not sprint_results.empty
-        if qual_results is not None:
-            qual_results = qual_results.merge(sprint_results, on='Abbreviation', how='left')
-        drivers_df = drivers_df.merge(sprint_results, on='Abbreviation', how='left')
-    except Exception:
-        sprint_results = pd.DataFrame()
-        has_sprint = False
-
-    if qual_results is not None and not qual_results.empty:
-        default_best_q = qual_results['BestTime'].median()
-        default_delta_next = qual_results.get('DeltaToNext', pd.Series()).mean()
-        default_delta_q3 = qual_results.get('DeltaToNext_Q3', pd.Series()).mean()
-        default_delta_q2 = qual_results.get('DeltaToNext_Q2', pd.Series()).mean()
-        if pd.isna(default_delta_next):
-            delta_series = (
-                qual_results.sort_values('BestTime')['BestTime'].diff(-1).abs()
-            )
-            default_delta_next = delta_series.mean()
-        if pd.isna(default_delta_q3):
-            default_delta_q3 = DELTA_NEXT_PENALTY
-        if pd.isna(default_delta_q2):
-            default_delta_q2 = DELTA_NEXT_PENALTY
-    else:
-        default_best_q = race_data['BestQualiTime'].median()
-        default_delta_next = race_data['DeltaToNext'].mean()
-        default_delta_q3 = race_data.get('DeltaToNext_Q3', pd.Series()).mean()
-        default_delta_q2 = race_data.get('DeltaToNext_Q2', pd.Series()).mean()
-        if pd.isna(default_delta_q3):
-            default_delta_q3 = DELTA_NEXT_PENALTY
-        if pd.isna(default_delta_q2):
-            default_delta_q2 = DELTA_NEXT_PENALTY
-
-    hist_air = race_data['AirTemp'].mean()
-    hist_track = race_data['TrackTemp'].mean()
-    hist_rain = race_data['Rainfall'].median()
-    if fp3_results is not None:
-        forecast = fetch_weather(grand_prix)
-        if forecast:
-            f_air = forecast['ForecastAirTemp']
-            f_track = f_air + 10
-            f_rain = forecast['ForecastPrecipChance']
-        else:
-            f_air = hist_air
-            f_track = hist_track
-            f_rain = hist_rain
-
-        event_date_dt = datetime(year, event_month, event_day)
-        today = datetime.now()
-        days_to_race = max(0, (event_date_dt - today).days)
-        alpha = _blend_alpha(days_to_race, grand_prix)
-
-        default_air = alpha * f_air + (1 - alpha) * hist_air
-        default_track = alpha * f_track + (1 - alpha) * hist_track
-        default_rain = alpha * f_rain + (1 - alpha) * hist_rain
-        default_fp3 = fp3_results['FP3BestTime'].mean()
-        default_fp3_long = fp3_results['FP3LongRunTime'].mean()
-    else:
-        default_air, default_track, default_rain = hist_air, hist_track, hist_rain
-        default_fp3 = race_data['FP3BestTime'].mean()
-        default_fp3_long = race_data['FP3LongRunTime'].mean()
-    default_overtake = race_data['Overtakes_CurrentYear'].mean()
-
-    try:
-        from fastf1.circuit_info import get_circuit_info
-        circuit_lengths = {}
-        corners_map = {}
-        drs_map = {}
-        lap_map = {}
-        info = get_circuit_info(grand_prix)
-        length = (
-            info.get('Length')
-            or info.get('CircuitLength')
-            or info.get('circuitLength')
-        )
-        corners = (
-            info.get('NumberOfTurns')
-            or info.get('Turns')
-            or info.get('numCorners')
-        )
-        drs = (
-            info.get('NumberOfDRSZones')
-            or info.get('DRSZonesCount')
-            or info.get('drsZones')
-        )
-        laptime = (
-            info.get('LapTimeAvg')
-            or info.get('LapRecord')
-            or info.get('lapRecord')
-        )
-        if isinstance(length, str):
-            length = str(length).replace(' km', '')
-        if isinstance(laptime, str):
-            try:
-                laptime = pd.to_timedelta(laptime).total_seconds()
-            except Exception:
-                laptime = pd.to_numeric(laptime, errors='coerce')
-        circuit_lengths[grand_prix] = pd.to_numeric(length, errors='coerce')
-        corners_map[grand_prix] = pd.to_numeric(corners, errors='coerce')
-        drs_map[grand_prix] = pd.to_numeric(drs, errors='coerce')
-        lap_map[grand_prix] = pd.to_numeric(laptime, errors='coerce')
-    except Exception:
-        meta = CIRCUIT_METADATA.get(grand_prix, {})
-        circuit_lengths = {grand_prix: np.nan}
-        corners_map = {grand_prix: meta.get('NumCorners', np.nan)}
-        drs_map = {grand_prix: meta.get('DRSZones', np.nan)}
-        lap_map = {grand_prix: meta.get('StdLapTime', np.nan)}
-
-    TRACK_TYPE = {
-        'Monaco Grand Prix': 'street',
-        'Singapore Grand Prix': 'street',
-        'Las Vegas Grand Prix': 'street',
-    }
-    DOWNFORCE = {
-        'Monaco Grand Prix': 'high',
-        'Hungarian Grand Prix': 'high',
-        'Italian Grand Prix': 'low',
-        'Belgian Grand Prix': 'low',
-    }
-    df_level_map = {'low': 0, 'medium': 1, 'high': 2}
-    track_type_val = TRACK_TYPE.get(grand_prix, 'permanent')
-    is_street_val = 1 if track_type_val == 'street' else 0
-    downforce_val = DOWNFORCE.get(grand_prix, 'medium')
-    downforce_level_val = df_level_map.get(downforce_val, 1)
-    circuit_length_val = circuit_lengths.get(grand_prix, np.nan)
-    num_corners_val = corners_map.get(grand_prix, np.nan)
-    drs_zones_val = drs_map.get(grand_prix, np.nan)
-    std_lap_time_val = lap_map.get(grand_prix, np.nan)
-
-    pred_rows = []
-    default_team_avg = race_data['Position'].mean()
-    default_team_quali = race_data['GridPosition'].mean()
-
-    (
-        driver_stats_lookup,
-        driver_pts_map,
-        constructor_pts_map,
-        driver_stand_map,
-        constructor_stand_map,
-        team_strength,
-        prev_rank_map,
-        default_prev_rank,
-    ) = _season_driver_team_stats(race_data, year)
-
-    if qual_results is not None and not qual_results.empty:
-        fastest = qual_results['BestTime'].min()
-        qual_results['DeltaToBestQuali'] = qual_results['BestTime'] - fastest
-        qual_results = qual_results.sort_values('BestTime')
-        qual_results['DeltaToNext'] = qual_results['BestTime'].diff(-1).abs()
-        qual_results = qual_results.sort_index()
-        team_mean = qual_results.groupby('Team')['BestTime'].transform('mean')
-        team_size = qual_results.groupby('Team')['BestTime'].transform('size')
-        qual_results['DeltaToTeammateQuali'] = np.where(team_size > 1,
-                                                       (qual_results['BestTime'] - team_mean) * 2,
-                                                       0)
-        if 'Q1' in qual_results.columns and 'Q3' in qual_results.columns:
-            qual_results['QualiSessionGain'] = qual_results['Q1'] - qual_results['Q3']
-            std = qual_results['QualiSessionGain'].std()
-            qual_results['QualiSessionGain'] = (
-                (qual_results['QualiSessionGain'] - qual_results['QualiSessionGain'].mean()) / std
-            ) if std != 0 else 0
-        else:
-            qual_results['QualiSessionGain'] = 0
-        qual_results['GridDropCount'] = 0
-
-    driver_iter = qual_results if qual_results is not None and not qual_results.empty else drivers_df
-    overall_avg_pos = race_data['Position'].mean()
-    rookie_avg_pos = race_data[race_data['ExperienceCount'] == 1]['Position'].mean()
-    for _, d in driver_iter.iterrows():
-        driver_num = d.get('DriverNumber')
-        if pd.notna(driver_num):
-            exp_count = len(race_data[race_data['DriverNumber'] == driver_num]) + 1
-        else:
-            exp_count = 1
-        team_name = d['Team']
-        team_same_season = race_data[
-            (race_data['HistoricalTeam'] == team_name) &
-            (race_data['Season'] == year)
-        ].sort_values('RaceNumber')
-        team_prev = team_same_season[team_same_season['RaceNumber'] < this_race_number]
-
-        if len(team_prev) > 0:
-            team_avg_pos = team_prev['Position'].mean()
-        else:
-            team_avg_pos = team_strength.get(team_name, default_team_avg)
-
-        team_prev_q = team_prev['GridPosition']
-        if len(team_prev_q) > 0:
-            team_recent_q = team_prev_q.tail(5).mean()
-        else:
-            team_recent_q = default_team_quali
-
-        team_prev_f = team_prev['Position']
-        if len(team_prev_f) > 0:
-            team_recent_f = team_prev_f.tail(5).mean()
-        else:
-            team_recent_f = default_team_avg
-
-        team_prev_dnf = team_prev['DidNotFinish']
-        if len(team_prev_dnf) > 0:
-            team_rel = team_prev_dnf.tail(5).sum()
-        else:
-            team_rel = 0.0
-
-        driver_num_val = d.get('DriverNumber')
-        key = (driver_num_val, grand_prix)
-        stats = driver_stats_lookup.loc[key] if driver_num_val is not None and key in driver_stats_lookup.index else None
-        if stats is None:
-            avg_track = race_data['DriverAvgTrackFinish'].mean()
-            podiums = 0.0
-            dnfs = 0.0
-        else:
-            avg_track = stats['DriverAvgTrackFinish']
-            podiums = stats['DriverTrackPodiums']
-            dnfs = stats['DriverTrackDNFs']
-
-        penalty = int(d.get('Penalty', 0))
-        if qual_results is not None and 'GridPosition' in d and pd.notna(d['GridPosition']):
-            grid_pos = int(d['GridPosition']) + penalty
-            best_time = d['BestTime']
-            grid_missed = 1 if grid_pos > 20 else 0
-        else:
-            grid_pos = 20 + penalty
-            best_time = default_best_q
-            grid_missed = 1
-
-        if fp3_results is not None and 'FP3BestTime' in d and pd.notna(d['FP3BestTime']):
-            fp3_time = d['FP3BestTime']
-        else:
-            fp3_time = default_fp3
-
-        if fp3_results is not None and 'FP3LongRunTime' in d and pd.notna(d['FP3LongRunTime']):
-            fp3_long_time = d['FP3LongRunTime']
-        else:
-            fp3_long_time = default_fp3_long
-
-        driver_num = d.get('DriverNumber')
-        if pd.isna(driver_num):
-            driver_num = -1
-        else:
-            driver_num = int(driver_num)
-        past_races = race_data[
-            (race_data['DriverNumber'] == driver_num) & (
-                (race_data['Season'] < year) |
-                ((race_data['Season'] == year) & (race_data['RaceNumber'] < this_race_number))
-            )
-        ].sort_values(['Season', 'RaceNumber'])
-
-        if past_races.empty:
-            cross_avg = rookie_avg_pos
-            recent_avg_pts = 0.0
-            recent3_avg = rookie_avg_pos
-            recent5_avg = rookie_avg_pos
-        else:
-            cross_avg = past_races['Position'].tail(5).mean()
-            recent_avg_pts = past_races['Points'].tail(5).mean()
-            recent3_avg = past_races['Position'].tail(3).mean()
-            recent5_avg = past_races['Position'].tail(5).mean()
-        pred_rows.append({
-            'GridPosition': grid_pos,
-            'GridMissed': grid_missed,
-            "DriverNumber": driver_num,
-            'Season': year,
-            'ExperienceCount': exp_count,
-            'IsRookie': 1 if exp_count == 1 else 0,
-            'TeamAvgPosition': team_avg_pos,
-            'CrossAvgFinish': cross_avg,
-            'RecentAvgPoints': recent_avg_pts,
-            'BestQualiTime': best_time,
-            'FP3BestTime': fp3_time,
-            'FP3LongRunTime': fp3_long_time,
-            'IsMissing_Q1Time': 1 if pd.isna(d.get('Q1')) else 0,
-            'IsMissing_Q3Time': 1 if pd.isna(d.get('Q3')) else 0,
-            'DeltaToBestQuali': d.get('DeltaToBestQuali', 0),
-            'DeltaToNext': d.get('DeltaToNext', default_delta_next),
-            'DeltaToNext_Q3': d.get('DeltaToNext_Q3', default_delta_q3),
-            'DeltaToNext_Q2': d.get('DeltaToNext_Q2', default_delta_q2),
-            'MissedQ3': d.get('MissedQ3', 1),
-            'MissedQ2': d.get('MissedQ2', 1),
-            'SprintFinish': d.get('SprintFinish'),
-            'HasSprint': 1 if has_sprint else 0,
-            'Recent3AvgFinish': recent3_avg,
-            'Recent5AvgFinish': recent5_avg,
-            'DriverAvgTrackFinish': avg_track,
-            'DriverTrackPodiums': podiums,
-            'DriverTrackDNFs': dnfs,
-            'TeamRecentQuali': team_recent_q,
-            'TeamRecentFinish': team_recent_f,
-            'TeamReliability': team_rel,
-                'DriverChampPoints': driver_pts_map.get(driver_num, 0.0),
-            'ConstructorChampPoints': constructor_pts_map.get(d['Team'], 0.0),
-                'DriverStanding': int(driver_stand_map.get(driver_num, 0)),
-            'ConstructorStanding': int(constructor_stand_map.get(d['Team'], 0)),
-            'PrevYearConstructorRank': prev_rank_map.get(team_name, default_prev_rank),
-            'CircuitLength': circuit_length_val,
-            'NumCorners': num_corners_val,
-            'DRSZones': drs_zones_val,
-            'StdLapTime': std_lap_time_val,
-            'IsStreet': is_street_val,
-            'DownforceLevel': downforce_level_val,
-            'AirTemp': default_air,
-            'TrackTemp': default_track,
-            'Rainfall': default_rain,
-            'Overtakes_CurrentYear': default_overtake,
-            'Team': d['Team'],
-            'FullName': d['FullName'],
-            'Abbreviation': d['Abbreviation']
-        })
-
-    pred_df = pd.DataFrame(pred_rows)
-
-    if pred_df.empty:
-        raise ValueError(f"No driver data available for {year} {grand_prix}")
-    driver_sprint_mean = race_data.groupby("DriverNumber")["SprintFinish"].mean()
-    team_sprint_mean = race_data.groupby("HistoricalTeam")["SprintFinish"].mean()
-    driver_sprint_mean = race_data.groupby("DriverNumber")["SprintFinish"].mean()
-    team_sprint_mean = race_data.groupby("HistoricalTeam")["SprintFinish"].mean()
-
-    pred_df['GridPosition'] = (
-        pd.to_numeric(pred_df['GridPosition'], errors='coerce')
-        .fillna(20)
+    pred_df = _build_pred_df(
+        race_data,
+        grand_prix,
+        year,
+        this_race_number,
+        event_month,
+        event_day,
+        safetycar_map,
     )
-    pred_df['GridMissed'] = pd.to_numeric(pred_df['GridMissed'], errors='coerce').fillna(0).astype(int)
-    pred_df['GridPosition'] = pred_df['GridPosition'].clip(lower=1)
-    pred_df['BestQualiTime'] = pd.to_numeric(pred_df['BestQualiTime'], errors='coerce')
-    pred_df['IsMissing_BestQualiTime'] = pred_df['BestQualiTime'].isna().astype(int)
-    pred_df['MissedQuali'] = pred_df['BestQualiTime'].isna().astype(int)
-    pred_df['BestQualiTime'] = pred_df['BestQualiTime'].fillna(
-        race_data['BestQualiTime'].median()
-    )
-    pred_df['QualiRank'] = pred_df['BestQualiTime'].rank(method='dense', ascending=True)
-    pred_df['GridRank'] = pred_df['GridPosition']
-    pred_df['QualiOverGrid'] = pred_df['QualiRank'] / pred_df['GridRank']
-    pred_df['DeltaToNext'] = pd.to_numeric(pred_df['DeltaToNext'], errors='coerce').fillna(default_delta_next)
-    pred_df['DeltaToNext_Q3'] = pd.to_numeric(pred_df['DeltaToNext_Q3'], errors='coerce').fillna(default_delta_q3)
-    pred_df['DeltaToNext_Q2'] = pd.to_numeric(pred_df['DeltaToNext_Q2'], errors='coerce').fillna(default_delta_q2)
-    pred_df['MissedQ3'] = pd.to_numeric(pred_df['MissedQ3'], errors='coerce').fillna(1).astype(int)
-    pred_df['MissedQ2'] = pd.to_numeric(pred_df['MissedQ2'], errors='coerce').fillna(1).astype(int)
-    pred_df['FP3BestTime'] = (
-        pd.to_numeric(pred_df['FP3BestTime'], errors='coerce')
-        .fillna(race_data['FP3BestTime'].mean())
-    )
-    pred_df['FP3LongRunTime'] = pd.to_numeric(pred_df['FP3LongRunTime'], errors='coerce')
-    pred_df['IsMissing_FP3LongRunTime'] = pred_df['FP3LongRunTime'].isna().astype(int)
-    pred_df['FP3LongRunTime'] = pred_df['FP3LongRunTime'].fillna(
-        race_data['FP3LongRunTime'].mean()
-    )
-    pred_df['SprintFinish'] = pd.to_numeric(pred_df.get('SprintFinish'), errors='coerce')
-    pred_df['HasSprint'] = pred_df['HasSprint'].fillna(0).astype(int)
-    pred_df['SprintFinish'] = pred_df.apply(
-        lambda r: driver_sprint_mean.get(r['DriverNumber']) if pd.isna(r['SprintFinish']) else r['SprintFinish'],
-        axis=1
-    )
-    pred_df['SprintFinish'] = pred_df.apply(
-        lambda r: team_sprint_mean.get(r['Team']) if pd.isna(r['SprintFinish']) else r['SprintFinish'],
-        axis=1
-    )
-    pred_df['SprintFinish'] = pred_df['SprintFinish'].fillna(race_data['SprintFinish'].mean())
-    pred_df['SprintFinish'] = pred_df['SprintFinish'].clip(1, 20)
-    pred_df['NumCorners'] = (
-        pd.to_numeric(pred_df['NumCorners'], errors='coerce')
-        .fillna(race_data['NumCorners'].median())
-    )
-    pred_df['DRSZones'] = (
-        pd.to_numeric(pred_df['DRSZones'], errors='coerce')
-        .fillna(race_data['DRSZones'].median())
-    )
-    pred_df['StdLapTime'] = (
-        pd.to_numeric(pred_df['StdLapTime'], errors='coerce')
-        .fillna(race_data['StdLapTime'].mean())
-    )
-
-    pred_df['Month'] = event_month
-
-    air_map = race_data.groupby(['Circuit', 'Month'])['AirTemp'].median()
-    air_val = air_map.get((grand_prix, event_month), np.nan)
-    pred_df['AirTemp'] = pd.to_numeric(pred_df['AirTemp'], errors='coerce')
-    pred_df['AirTemp'] = pred_df['AirTemp'].fillna(air_val)
-    pred_df['AirTemp'] = pred_df['AirTemp'].fillna(race_data['AirTemp'].mean())
-
-    track_map = race_data.groupby(['Circuit', 'Month'])['TrackTemp'].median()
-    track_val = track_map.get((grand_prix, event_month), np.nan)
-    pred_df['TrackTemp'] = pd.to_numeric(pred_df['TrackTemp'], errors='coerce')
-    pred_df['TrackTemp'] = pred_df['TrackTemp'].fillna(track_val)
-    pred_df['TrackTemp'] = pred_df['TrackTemp'].fillna(race_data['TrackTemp'].mean())
-
-    pred_df['Rainfall'] = pd.to_numeric(pred_df['Rainfall'], errors='coerce')
-    pred_df['IsMissing_Rainfall'] = pred_df['Rainfall'].isna().astype(int)
-    rain_map = race_data.groupby(['Circuit', 'Month'])['Rainfall'].median()
-    rain_val = rain_map.get((grand_prix, event_month), np.nan)
-    pred_df['Rainfall'] = pred_df['Rainfall'].fillna(rain_val)
-    circ_rain_map = race_data.groupby('Circuit')['Rainfall'].median()
-    circuit_rain = circ_rain_map.get(grand_prix, race_data['Rainfall'].median())
-    pred_df['Rainfall'] = pred_df['Rainfall'].fillna(circuit_rain)
-    pred_df['Rainfall'] = pred_df['Rainfall'].fillna(race_data['Rainfall'].median())
-
-    sc_vals = [v for d in safetycar_map.values() for v in d.values()]
-    global_sc = float(np.mean(sc_vals)) if sc_vals else np.nan
-    circ_sc_vals = safetycar_map.get(grand_prix, {})
-    sc_avg = float(np.mean(list(circ_sc_vals.values()))) if circ_sc_vals else global_sc
-    if 'SafetyCarAvg' not in pred_df.columns:
-        pred_df['SafetyCarAvg'] = sc_avg
-    else:
-        pred_df['SafetyCarAvg'] = pd.to_numeric(pred_df['SafetyCarAvg'], errors='coerce')
-        pred_df['SafetyCarAvg'] = pred_df['SafetyCarAvg'].fillna(sc_avg)
-
-    if 'LikelihoodSC' not in pred_df.columns:
-        pred_df['LikelihoodSC'] = SC_CORR_MAP.get(grand_prix, SC_CORR_GLOBAL)
-    else:
-        pred_df['LikelihoodSC'] = pd.to_numeric(pred_df['LikelihoodSC'], errors='coerce')
-        pred_df['LikelihoodSC'] = pred_df['LikelihoodSC'].fillna(
-            SC_CORR_MAP.get(grand_prix, SC_CORR_GLOBAL)
-        )
-    pred_df = pred_df.drop(columns=['Month'], errors='ignore')
-
     pred_df.to_csv("prediction_input.csv", index=False)
 
     race_pred_features, _, _, _ = _encode_features(
@@ -701,9 +278,7 @@ def predict_race(
         circuit_enc,
         top_circuits,
     )
-
     pred_features = race_pred_features.reindex(columns=features.columns, fill_value=0)
-
     preds = model.predict(pred_features)
     shap_values = None
     if debug and shap is not None:
@@ -847,7 +422,7 @@ def _build_pred_df(
     event_month,
     event_day,
     safetycar_map,
-):
+): 
     """Assemble a prediction input frame for a single event."""
 
     # Some cached datasets from older versions dropped the "Month" column.
@@ -859,21 +434,50 @@ def _build_pred_df(
             )
         else:
             race_data = race_data.assign(Month=np.nan)
+
+    driver_lookup = {}
+    try:
+        with open("driver_lookup.csv", newline="", encoding="utf-8") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                abbr = row.get("Abbreviation")
+                num = row.get("DriverNumber")
+                if abbr and num:
+                    driver_lookup[abbr.strip()] = int(num)
+    except Exception as e:
+        logger.error("Kon driver_lookup.csv niet inlezen: %s", e)
     try:
         drivers_df = _get_qualifying_results(year, grand_prix)
+        if drivers_df.empty or "DriverNumber" not in drivers_df.columns:
+            raise ValueError("Geen valide DriverNumber in kwalificatiegegevens")
         drivers_df = drivers_df[drivers_df["BestTime"].notna()]
         qual_results = drivers_df.copy()
-    except Exception:
-        drivers_df = _get_event_drivers(year, grand_prix)
-        qual_results = None
+    except Exception as e:
+        logger.warning(
+            "Kwalificatie ophalen mislukt voor %d %s: %s", year, grand_prix, e
+        )
+        try:
+            drivers_df = _get_event_drivers(year, grand_prix)
+            drivers_df["DriverNumber"] = drivers_df["Abbreviation"].map(driver_lookup)
+            missing = drivers_df[drivers_df["DriverNumber"].isna()]["Abbreviation"].tolist()
+            if missing:
+                logger.warning("Kon geen DriverNumber vinden voor afkortingen: %s", missing)
+            qual_results = None
+        except Exception as e2:
+            logger.error("_get_event_drivers mislukt voor %d %s: %s", year, grand_prix, e2)
+            drivers_df = pd.DataFrame(columns=["Abbreviation", "DriverNumber"])
+            qual_results = None
 
     drivers_df["DriverNumber"] = pd.to_numeric(drivers_df["DriverNumber"], errors="coerce")
 
     try:
         fp3_results = _get_fp3_results(year, grand_prix)
+        if "DriverNumber" not in fp3_results.columns or fp3_results["DriverNumber"].isna().all():
+            raise ValueError("Geen valide DriverNumber in FP3-gegevens")
         if qual_results is not None:
             qual_results = qual_results.merge(fp3_results, on="Abbreviation", how="left")
-    except Exception:
+    except Exception as e:
+        logger.warning("FP3 ophalen mislukt voor %d %s: %s", year, grand_prix, e)
         fp3_results = None
 
     try:
@@ -882,7 +486,8 @@ def _build_pred_df(
         if qual_results is not None:
             qual_results = qual_results.merge(sprint_results, on="Abbreviation", how="left")
         drivers_df = drivers_df.merge(sprint_results, on="Abbreviation", how="left")
-    except Exception:
+    except Exception as e:
+        logger.warning("Sprint ophalen mislukt voor %d %s: %s", year, grand_prix, e)
         sprint_results = pd.DataFrame()
         has_sprint = False
 
@@ -1054,8 +659,14 @@ def _build_pred_df(
     for _, d in driver_iter.iterrows():
         driver_num = d.get("DriverNumber")
         if pd.notna(driver_num):
-            exp_count = len(race_data[race_data["DriverNumber"] == driver_num]) + 1
+            try:
+                prev_count = race_data[race_data["DriverNumber"] == int(driver_num)].shape[0]
+                exp_count = prev_count + 1
+            except Exception as e:
+                logger.warning("Fout bij tellen eerdere races voor driver %s: %s", driver_num, e)
+                exp_count = 1
         else:
+            logger.error("DriverNumber ontbreekt voor rij: %s", d.get("Abbreviation"))
             exp_count = 1
         team_name = d["Team"]
         team_same_season = race_data[


### PR DESCRIPTION
## Summary
- add csv import
- simplify prediction input creation using `_build_pred_df`
- load `driver_lookup.csv` in `_build_pred_df`
- fill driver numbers via lookup and add logging when sessions fail
- compute experience counts robustly
- added sample `driver_lookup.csv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f698704b483318a326ed537d64aca