### PR TITLE
Fix team history lookup for early races

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -643,16 +643,19 @@ def _load_historical_data(
     return pd.concat(race_data)
 
 
-def _add_driver_team_info(full_data, seasons):
+def _add_driver_team_info(full_data, seasons, max_round_by_season=None):
     """Attach driver team information using historical race results.
 
     Driver line-ups can change mid-season.  To capture this the function
     collects the team for every race in ``seasons`` and, for each row in
     ``full_data``, assigns the team from the latest race at or before that
-    event.
+    event.  When ``max_round_by_season`` is provided only rounds up to the
+    specified value are queried for each season.
     """
 
     season_history = {}
+
+    max_round_by_season = max_round_by_season or {}
 
     for season in seasons:
         try:
@@ -662,6 +665,10 @@ def _add_driver_team_info(full_data, seasons):
             )
         except Exception:
             continue
+
+        if season in max_round_by_season:
+            limit = max_round_by_season[season]
+            rounds = [r for r in rounds if r <= limit]
 
         race_map = {}
         for rnd in sorted(rounds):

--- a/pipeline.py
+++ b/pipeline.py
@@ -116,7 +116,7 @@ def predict_race(
     race_data['DriverNumber'] = pd.to_numeric(race_data['DriverNumber'], errors='coerce')
     qual_results = None
     fp3_results = None
-    race_data = _add_driver_team_info(race_data, seasons)
+    race_data = _add_driver_team_info(race_data, seasons, limit_rounds)
     race_data = race_data.drop(columns=['Team'], errors='ignore')
     race_data = race_data.loc[
         ~((race_data['Season'] == year) & (race_data['RaceNumber'] >= this_race_number))

--- a/tests/test_driver_team_info.py
+++ b/tests/test_driver_team_info.py
@@ -32,3 +32,28 @@ def test_driver_team_assignment_across_rounds(monkeypatch):
 
     result = _add_driver_team_info(df.copy(), [2024])
     assert list(result['HistoricalTeam']) == ['A', 'B', 'A', 'B', 'C', 'B']
+
+
+def test_driver_team_assignment_with_limit(monkeypatch):
+    def fake_get_event_schedule(year):
+        return pd.DataFrame({'RoundNumber': [1, 2, 3]})
+
+    def fake_get_session(year, rnd, kind):
+        mapping = {
+            1: pd.DataFrame({'DriverNumber': [1, 2], 'TeamName': ['A', 'B']}),
+            2: pd.DataFrame({'DriverNumber': [1, 2], 'TeamName': ['A', 'B']}),
+            3: pd.DataFrame({'DriverNumber': [1, 2], 'TeamName': ['C', 'B']}),
+        }
+        return FakeSession(mapping[rnd])
+
+    monkeypatch.setattr('data_utils.get_event_schedule', fake_get_event_schedule)
+    monkeypatch.setattr('data_utils.get_session', fake_get_session)
+
+    df = pd.DataFrame({
+        'Season': [2024, 2024, 2024, 2024, 2024, 2024],
+        'RaceNumber': [1, 1, 2, 2, 3, 3],
+        'DriverNumber': [1, 2, 1, 2, 1, 2],
+    })
+
+    result = _add_driver_team_info(df.copy(), [2024], {2024: 2})
+    assert list(result['HistoricalTeam']) == ['A', 'B', 'A', 'B', 'A', 'B']


### PR DESCRIPTION
## Summary
- avoid loading team data from future rounds
- cap requested rounds in `_add_driver_team_info`
- ensure pipeline passes limit to team info loader
- test team lookup when rounds are limited

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6842d79fdab483318070667ce5cf0acd